### PR TITLE
Support for multiple days via a single program

### DIFF
--- a/IDay.cs
+++ b/IDay.cs
@@ -1,0 +1,6 @@
+public interface IDay
+{
+    static abstract int PartOne(string[] lines);
+
+    static abstract int PartTwo(string[] lines);
+}

--- a/Program.cs
+++ b/Program.cs
@@ -5,7 +5,7 @@ void Resolve<T>(int dayNumber) where T : IDay
     var lines = ReadInput(dayNumber);
 
     var partOneResult = T.PartOne(lines);
-    var partTwoResult = T.PartOne(lines);
+    var partTwoResult = T.PartTwo(lines);
 
     PrintToConsole(dayNumber, partOneResult, partTwoResult);
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,27 @@
-﻿string[] ReadInput(int dayNumber)
+﻿Resolve<DayOne>(1);
+
+void Resolve<T>(int dayNumber) where T : IDay
+{
+    var lines = ReadInput(dayNumber);
+
+    var partOneResult = T.PartOne(lines);
+    var partTwoResult = T.PartOne(lines);
+
+    PrintToConsole(dayNumber, partOneResult, partTwoResult);
+}
+
+void PrintToConsole(int dayNumber, int partOneResult, int partTwoResult)
+{
+    Console.WriteLine($"""
+    #########################################
+    # Solution for day number: {dayNumber}
+    # Solution for part one:   {partOneResult}
+    # Solution for part two:   {partTwoResult}
+    #########################################{Environment.NewLine}
+    """);
+}
+
+string[] ReadInput(int dayNumber)
 {
     return File.ReadAllLines($"./day-{dayNumber}/input.txt");
 }

--- a/advent-of-code-2022.csproj
+++ b/advent-of-code-2022.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/day-1/DayOne.cs
+++ b/day-1/DayOne.cs
@@ -1,4 +1,4 @@
-public static class DayOne
+public sealed class DayOne : IDay
 {
     public static int PartOne(string[] lines)
     {


### PR DESCRIPTION
Before adding a day to execute at start-up required a couple of lines of code. Reducing the duplication of code by using an interface called ``IDay``. This interface force each day class to expose the static method `PartOne` and `PartTwo`.

From C# 8 it is possible to define ``static`` method in an interface. With C# 11 they even added support for ``abstract static``. Using static methods as there is no reason to initialize an object at this moment.